### PR TITLE
Migrate to ES6 modules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules/
+yarn.lock

--- a/kiigame.html
+++ b/kiigame.html
@@ -13,7 +13,6 @@
     <div id="container"></div>
 
     <script src="node_modules/konva/konva.min.js"></script>
-    <script type="module" src="kiigame.js"></script>
     <script type="module" src="latkazombit.js"></script>
   </body>
   

--- a/kiigame.html
+++ b/kiigame.html
@@ -10,18 +10,11 @@
     </style>
   </head>
   <body>
-    <div id="container"></div>                        
+    <div id="container"></div>
 
     <script src="node_modules/konva/konva.min.js"></script>
-    <script src="util/JSONGetter.js"></script>
-    <script src="view/stage/konvadata/LayerAdder.js"></script>
-    <script src="view/stage/konvadata/LayerChildAdder.js"></script>
-    <script src="view/sequence/konvadata/SequencesBuilder.js"></script>
-    <script src="view/sequence/konvadata/SequenceBuilder.js"></script>
-    <script src="view/sequence/konvadata/SlideBuilder.js"></script>
-    <script src="view/sequence/konvadata/TextBuilder.js"></script>
-    <script src="kiigame.js"></script>
-    <script src="latkazombit.js"></script>
+    <script type="module" src="kiigame.js"></script>
+    <script type="module" src="latkazombit.js"></script>
   </body>
   
 </html>

--- a/kiigame.js
+++ b/kiigame.js
@@ -1,6 +1,14 @@
+import JSONGetter from './util/JSONGetter.js';
+import LayerAdder from './view/stage/konvadata/LayerAdder.js';
+import LayerChildAdder from './view/stage/konvadata/LayerChildAdder.js';
+import SequencesBuilder from './view/sequence/konvadata/SequencesBuilder.js';
+import SequenceBuilder from './view/sequence/konvadata/SequenceBuilder.js';
+import SlideBuilder from './view/sequence/konvadata/SlideBuilder.js';
+import TextBuilder from './view/sequence/konvadata/TextBuilder.js';
+
 // Global variables. TODO: refactor
 // JSONs got from the server
-var texts_json; // also accessed from latkazombit.js
+export var texts_json; // also accessed from latkazombit.js
 var interactions_json;
 var character_json;
 var sequences_json;
@@ -8,7 +16,7 @@ var music_json;
 var menu_json;
 
 // Konva root node that includes all the images created from data
-var stage; // also accessed from latkazombit.js
+export var stage; // also accessed from latkazombit.js
 
 // Define variables from stage for easier use
 
@@ -60,7 +68,7 @@ var current_music;
 var current_music_source;
 
 // Menu
-var menu;
+export var menu;
 // Track the currently shown menu
 var current_menu;
 
@@ -89,10 +97,10 @@ var idle_animation;
 // Variable for saving the current room (for changing backgrounds and object layers)
 var current_layer;
 var current_background;
-var game_start_layer;
-var start_layer; // also accessed in latkazombit.js
+export var game_start_layer;
+export var start_layer; // also accessed in latkazombit.js
 
-class KiiGame {
+export class KiiGame {
     constructor(jsonGetter, sequencesBuilder) {
         this.jsonGetter = jsonGetter;
         this.sequencesBuilder = sequencesBuilder;
@@ -1338,4 +1346,4 @@ let sequencesBuilder = new SequencesBuilder(
     )
 );
 let kiigame = new KiiGame(jsonGetter, sequencesBuilder);
-
+export default kiigame;

--- a/kiigame.js
+++ b/kiigame.js
@@ -1348,3 +1348,5 @@ export class KiiGame {
     }
     
 }
+
+export default KiiGame;

--- a/kiigame.js
+++ b/kiigame.js
@@ -255,40 +255,40 @@ class KiiGame {
 
         // On window load we create image hit regions for our items on object layers
         // Loop backgrounds to create item hit regions and register mouseup event
-        window.onload = function() {
-            stage.getChildren().each(function(o) {
+        window.onload = () => {
+            stage.getChildren().each((o) => {
                 if (o.getAttr('category') == 'room') {
-                    o.getChildren().each(function(shape, i) {
+                    o.getChildren().each((shape, i) => {
                         if (shape.getAttr('category') != 'secret' && shape.className == 'Image') {
                             shape.cache();
                             shape.drawHitFromCache();
                         }
                     });
 
-                    o.on('mouseup touchend', function(event) {
+                    o.on('mouseup touchend', (event) => {
                         this.handle_click(event);
-                    }.bind(this));
+                    });
                 }
-            }.bind(this));
+            });
 
             stage.draw();
             idle_animation[0].node.show();
             idle_animation[0].play();
-        }.bind(this);
+        };
 
         // Mouse up and touch end events (picking up items from the environment
         // Mouse click and tap events (examine items in the inventory)
-        inventory_layer.on('click tap', function(event) {
+        inventory_layer.on('click tap', (event) => {
             this.handle_click(event);
-        }.bind(this));
+        });
         // Drag start events
-        stage.find('Image').on('dragstart', function(event) {
+        stage.find('Image').on('dragstart', (event) => {
             dragged_item = event.target;
             this.inventoryDrag(dragged_item);
-        }.bind(this));
+        });
 
         // While dragging events (use item on item or object)
-        stage.on('dragmove', function(event) {
+        stage.on('dragmove', (event) => {
             dragged_item = event.target;
 
             if (!delayEnabled) {
@@ -359,10 +359,10 @@ class KiiGame {
 
                 // If target is found, highlight it and show the interaction text
                 if (target != null) {
-                    current_layer.getChildren().each(function(shape, i) {
+                    current_layer.getChildren().each((shape, i) => {
                         shape.shadowBlur(0);
                     });
-                    inventory_layer.getChildren().each(function(shape, i) {
+                    inventory_layer.getChildren().each((shape, i) => {
                         shape.shadowBlur(0);
                     });
                     target.clearCache();
@@ -387,10 +387,10 @@ class KiiGame {
                     text_layer.draw();
                 } else {
                     // If no target, clear the texts and highlights
-                    current_layer.getChildren().each(function(shape, i) {
+                    current_layer.getChildren().each((shape, i) => {
                         shape.shadowBlur(0);
                     });
-                    inventory_layer.getChildren().each(function(shape, i) {
+                    inventory_layer.getChildren().each((shape, i) => {
                         shape.shadowBlur(0);
                     });
                     this.clearText(interaction_text);
@@ -398,29 +398,29 @@ class KiiGame {
 
                 current_layer.draw();
             }
-        }.bind(this));
+        });
 
         /// Stop character animations and clear monologue when clicked or touched
         /// anywhere on the screen.
-        stage.on('touchstart mousedown', function(event) {
+        stage.on('touchstart mousedown', (event) => {
             this.clearText(monologue);
             this.clearText(npc_monologue);
             this.stopCharacterAnimations();
-        }.bind(this));
+        });
 
         /// Touch start and mouse down events (save the coordinates before dragging)
-        inventory_layer.on('touchstart mousedown', function(event) {
+        inventory_layer.on('touchstart mousedown', (event) => {
             dragStartX = event.target.x();
             dragStartY = event.target.y();
         });
 
         /// Inventory arrow clicking events
-        inventory_bar_layer.on('click tap', function(event) {
+        inventory_bar_layer.on('click tap', (event) => {
             this.handle_click(event);
-        }.bind(this));
+        });
 
         /// Drag end events for inventory items.
-        stage.find('Image').on('dragend', function(event) {
+        stage.find('Image').on('dragend', (event) => {
             var dragged_item = event.target;
 
             // If nothing's under the dragged item
@@ -454,24 +454,24 @@ class KiiGame {
             }
 
             // Clearing the glow effects
-            current_layer.getChildren().each(function(shape, i) {
+            current_layer.getChildren().each((shape, i) => {
                 shape.shadowBlur(0);
-            }.bind(this));
-            inventory_layer.getChildren().each(function(shape, i) {
+            });
+            inventory_layer.getChildren().each((shape, i) => {
                 shape.shadowBlur(0);
-            }.bind(this));
+            });
             // Clearing the texts
             this.clearText(interaction_text);
 
             this.redrawInventory();
-        }.bind(this));
+        });
 
         // Set start layer
-        stage.getChildren().each(function(o) {
+        stage.getChildren().each((o) => {
             if (o.getAttr('category') === 'room' && o.getAttr('start') === true) {
                 game_start_layer = o;
             }
-        }.bind(this));
+        });
 
         // Not using getObject (with its error messaging), because these are optional.
         start_layer = stage.find("#start_layer")[0]; // TODO: get rid of start_layer
@@ -482,14 +482,14 @@ class KiiGame {
             current_background = 'start_layer';
             current_layer = start_layer;
             if (stage.find('#splash_screen')[0] != null) {
-                stage.find('#splash_screen')[0].on('tap click', function(event) {
+                stage.find('#splash_screen')[0].on('tap click', (event) => {
                     stage.find('#splash_screen')[0].hide();
                     if (stage.find('#start_layer_menu')[0] != null) {
                         this.display_start_menu();
                     } else {
                         this.do_transition(game_start_layer.id());
                     }
-                }.bind(this));
+                });
             } else { // no splash screen
                 if (stage.find('#start_layer_menu')[0] != null) {
                     this.display_start_menu();
@@ -514,9 +514,9 @@ class KiiGame {
             easing: Konva.Easings.EaseInOut,
             duration: attrs.duration,
 
-            onFinish: function() {
+            onFinish: () => {
                 animation.reverse();
-                setTimeout(function() {
+                setTimeout(() => {
                     animation.play();
                 }, attrs.duration * 1000);
             }
@@ -550,7 +550,7 @@ class KiiGame {
             }
 
             if (item_action == "start_game") {
-                item.on('tap click', function(event) {
+                item.on('tap click', (event) => {
                     if (this.getObject("intro") != "") {
                         var intro_delay = this.play_sequence("intro", true);
                         setTimeout('this.do_transition(game_start_layer.id(), 0)', intro_delay);
@@ -558,17 +558,17 @@ class KiiGame {
                         // Assume intro layer has a transition to game_start_layer
                         this.do_transition(game_start_layer.id());
                     }
-                }.bind(this));
+                });
             } else if (item_action == "credits") {
-                item.on('tap click', function(event) {
+                item.on('tap click', (event) => {
                     this.setMonologue(this.findMonologue(event.target.id()));
-                }.bind(this));
+                });
             } else if (item_action == "main_menu") {
                 // TODO: Return to main menu after end of game.
-                item.on('tap click', function(event) {
+                item.on('tap click', (event) => {
                     this.getObject("end_texts").hide();
                     this.display_start_menu();
-                }.bind(this));
+                });
             }
         }
     }
@@ -645,7 +645,7 @@ class KiiGame {
                 current_music.faded = true;
 
                 if (old_music) {
-                    var fade_interval_2 = setInterval(function() {
+                    var fade_interval_2 = setInterval(() => {
                         // Audio API will throw exception when volume is maxed
                         try {
                             old_music.volume -= 0.05;
@@ -661,7 +661,7 @@ class KiiGame {
                         }
                     }, 200)
                 } else if (current_music) {
-                    var fade_interval = setInterval(function() {
+                    var fade_interval = setInterval(() => {
                         // Audio API will throw exception when volume is maxed
                         try {
                             current_music.volume += 0.05
@@ -690,7 +690,7 @@ class KiiGame {
 
         // Fade music volume if set so
         if (current_music.faded === true) {
-            var fade_interval = setInterval(function() {
+            var fade_interval = setInterval(() => {
                 // Audio API will throw exception when volume is maxed
                 // or an crossfade interval may still be running
                 try {
@@ -699,7 +699,7 @@ class KiiGame {
                 } catch (e) {
                     clearInterval(fade_interval);
                 }
-            }.bind(this), 100)
+            }, 100)
         } else {
             current_music.pause();
         }
@@ -735,8 +735,8 @@ class KiiGame {
             var lastSlide = slide;
             slide = this.getObject(sequence.slides[i].id);
 
-            (function(i, slide, lastSlide) {
-                setTimeout(function() {
+            var displaySlide = (i, slide, lastSlide) => {
+                setTimeout(() => {
                     current_layer.show();
                     old_layer.hide();
                     fade_layer_full.show();
@@ -754,7 +754,7 @@ class KiiGame {
                     // Fade-in the slide
                     var slideFade = sequence.slides[i].do_fade;
                     if (slideFade === true) {
-                        setTimeout(function() {
+                        setTimeout(() => {
                             fade_full.reverse();
                             stage.draw();
                         }, 700);
@@ -766,29 +766,30 @@ class KiiGame {
 
                     sequenceCounter += 1;
 
-                }.bind(this), delay);
-            }.bind(this))(i, slide, lastSlide);
+                }, delay);
+            }
+            displaySlide(i, slide, lastSlide);
 
             delay = delay + sequence.slides[i].show_time;
         };
 
         // After last slide, do the final fade and set up exit monologue.
         if (final_fade_duration > 0) {
-            setTimeout(function() {
+            setTimeout(() => {
                 fade_full.tween.duration = final_fade_duration;
                 fade_full.play();
 
-                setTimeout(function() {
+                setTimeout(() => {
                     fade_full.reverse();
-                    setTimeout(function() {
+                    setTimeout(() => {
                         fade_layer_full.hide();
                         fade_full.tween.duration = 600; // reset to default
                         if (monologue === true) {
                             this.setMonologue(sequence_exit_text);
                         }
-                    }.bind(this), final_fade_duration);
-                }.bind(this), final_fade_duration);
-            }.bind(this), delay);
+                    }, final_fade_duration);
+                }, final_fade_duration);
+            }, delay);
 
             // Doesn't include the fade-in!
             delay = delay + final_fade_duration;
@@ -818,7 +819,7 @@ class KiiGame {
             fade_room.play();
         }
 
-        setTimeout(function() {
+        setTimeout(() => {
             this.stop_music();
             // Don't fade if duration is zero.
             if (fade_time != 0) {
@@ -847,14 +848,14 @@ class KiiGame {
             character_layer.show();
             stage.draw();
 
-            setTimeout(function() {
+            setTimeout(() => {
                 fade_layer_room.hide();
                 this.play_music(current_layer.id());
                 if (comingFrom) {
                     this.setMonologue(this.findMonologue(comingFrom));
                 }
-            }.bind(this), fade_time);
-        }.bind(this), fade_time);
+            }, fade_time);
+        }, fade_time);
     }
 
     // Basic intersection check; checking whether corners of the dragged item are inside the area of the intersecting object
@@ -930,11 +931,11 @@ class KiiGame {
     handle_commands(commands) {
         for (var i in commands) {
             if (commands[i].timeout != null) {
-                (function(commands, i) {
-                    setTimeout(function() {
+                ((commands, i) => {
+                    setTimeout(() => {
                         this.handle_command(commands[i]);
-                    }.bind(this), commands[i].timeout);
-                }.bind(this))(commands, i);
+                    }, commands[i].timeout);
+                })(commands, i);
             } else {
                 this.handle_command(commands[i]);
             }
@@ -1028,7 +1029,7 @@ class KiiGame {
         fade_layer_full.show();
         fade_full.play();
 
-        setTimeout(function() {
+        setTimeout(() => {
             // Clear inventory except rewards
             for (var i = inventory_layer.children.length-1; i >= 0; i--) {
                 var shape = inventory_layer.children[i];
@@ -1056,7 +1057,7 @@ class KiiGame {
 
             fade_full.reverse();
             setTimeout('fade_layer_full.hide();', 700);
-        }.bind(this), 700);
+        }, 700);
     }
 
     // Clearing the given text
@@ -1179,9 +1180,9 @@ class KiiGame {
         character_layer.draw();
 
         clearTimeout(character_animation_timeout);
-        character_animation_timeout = setTimeout(function() {
+        character_animation_timeout = setTimeout(() => {
             this.stopCharacterAnimations();
-        }.bind(this), timeout);
+        }, timeout);
     }
 
     ///Stop the characer animations, start idle animation
@@ -1224,9 +1225,9 @@ class KiiGame {
     // Setting an image to the stage and scaling it based on relative values if they exist
     createObject(o) {
         window[o.id] = new Image();
-        window[o.id].onLoad = function() {
+        window[o.id].onLoad = (() => {
             this.getObject(o.id).image(window[o.id]);
-        }.bind(this)();
+        })();
         window[o.id].src = o.src;
     }
 
@@ -1281,7 +1282,7 @@ class KiiGame {
     /// Redrawing inventory. Shows the items that should be visible according to
     /// inventory_index and takes care of showing inventory arrows as necessary.
     redrawInventory() {
-        inventory_layer.getChildren().each(function(shape, i) {
+        inventory_layer.getChildren().each((shape, i) => {
             shape.setAttr('visible', false);
             shape.draggable(false);
         });

--- a/kiigame.js
+++ b/kiigame.js
@@ -68,7 +68,7 @@ var current_music;
 var current_music_source;
 
 // Menu
-export var menu;
+export var menu; // also accessed in latkazombit.js
 // Track the currently shown menu
 var current_menu;
 
@@ -88,7 +88,7 @@ var fade_room;
 var animated_objects = [];
 
 // Create character animations.
-var character_animations = [];
+export var character_animations = []; // also accessed in latkazombit.js
 
 // Default character animations
 var speak_animation;
@@ -97,7 +97,7 @@ var idle_animation;
 // Variable for saving the current room (for changing backgrounds and object layers)
 var current_layer;
 var current_background;
-export var game_start_layer;
+export var game_start_layer; // also accessed in latkazombit.js
 export var start_layer; // also accessed in latkazombit.js
 
 export class KiiGame {

--- a/kiigame.js
+++ b/kiigame.js
@@ -101,9 +101,22 @@ export var game_start_layer; // also accessed in latkazombit.js
 export var start_layer; // also accessed in latkazombit.js
 
 export class KiiGame {
-    constructor(jsonGetter, sequencesBuilder) {
+    constructor(jsonGetter = null, sequencesBuilder = null) {
         this.jsonGetter = jsonGetter;
         this.sequencesBuilder = sequencesBuilder;
+
+        if (this.jsonGetter === null) {
+            this.jsonGetter = new JSONGetter();
+        }
+        if (this.sequencesBuilder === null) {
+            this.sequencesBuilder = new SequencesBuilder(
+                new SequenceBuilder(
+                    new SlideBuilder(
+                        new TextBuilder()
+                    )
+                )
+            );
+        }
 
         // Get jsons from the server
         var images_json = JSON.parse(this.getJSON('images.json'));
@@ -1335,15 +1348,3 @@ export class KiiGame {
     }
     
 }
-
-
-let jsonGetter = new JSONGetter();
-let sequencesBuilder = new SequencesBuilder(
-    new SequenceBuilder(
-        new SlideBuilder(
-            new TextBuilder()
-        )
-    )
-);
-let kiigame = new KiiGame(jsonGetter, sequencesBuilder);
-export default kiigame;

--- a/kiigame.js
+++ b/kiigame.js
@@ -344,12 +344,12 @@ class KiiGame {
                             dragDelayEnabled = true;
                             inventory_index--;
                             this.redrawInventory();
-                            setTimeout('dragDelayEnabled = false;', dragDelay);
+                            setTimeout(() => dragDelayEnabled = false, dragDelay);
                         } else if (this.checkIntersection(dragged_item, rightArrow)) {
                             dragDelayEnabled = true;
                             inventory_index++;
                             this.redrawInventory();
-                            setTimeout('dragDelayEnabled = false;', dragDelay);
+                            setTimeout(() => dragDelayEnabled = false, dragDelay);
                         } else {
                             target = null;
                         }
@@ -553,7 +553,9 @@ class KiiGame {
                 item.on('tap click', (event) => {
                     if (this.getObject("intro") != "") {
                         var intro_delay = this.play_sequence("intro", true);
-                        setTimeout('this.do_transition(game_start_layer.id(), 0)', intro_delay);
+                        setTimeout(() => {
+                            this.do_transition(game_start_layer.id(), 0)
+                        }, intro_delay);
                     } else {
                         // Assume intro layer has a transition to game_start_layer
                         this.do_transition(game_start_layer.id());
@@ -1056,7 +1058,7 @@ class KiiGame {
             rewards_text.text(old_text);
 
             fade_full.reverse();
-            setTimeout('fade_layer_full.hide();', 700);
+            setTimeout(() => fade_layer_full.hide(), 700);
         }, 700);
     }
 
@@ -1321,7 +1323,7 @@ class KiiGame {
     // Delay to be set after each intersection check
     setDelay(delay) {
         delayEnabled = true;
-        setTimeout('delayEnabled = false;', delay);
+        setTimeout(() => delayEnabled = false, delay);
     }
     
 }

--- a/latkazombit.js
+++ b/latkazombit.js
@@ -3,7 +3,8 @@ import kiigame, {
     texts_json,
     game_start_layer,
     start_layer,
-    menu
+    menu,
+    character_animations
 } from './kiigame.js';
 
 var legends_json = JSON.parse(kiigame.getJSON('legends.json'));

--- a/latkazombit.js
+++ b/latkazombit.js
@@ -1,3 +1,11 @@
+import kiigame, {
+    stage,
+    texts_json,
+    game_start_layer,
+    start_layer,
+    menu
+} from './kiigame.js';
+
 var legends_json = JSON.parse(kiigame.getJSON('legends.json'));
 
 stage.find("#locker_room_1")[0].setSize(stage.getWidth(), stage.getHeight() - 100);
@@ -39,7 +47,7 @@ stage.find('#start')[0].on('tap click', function(event) {
 
 // Listeners for the input screen buttons
 input_layer.on('tap click', function(event) {
-	target = event.target;
+	var target = event.target;
 	
 	var selected = texts_json[target.getAttr('id')];
 	if (selected)
@@ -159,7 +167,7 @@ input_layer.on('tap click', function(event) {
 		input_layer.hide();
 
 	    var intro_delay = kiigame.play_sequence("intro", true);
-        setTimeout('kiigame.do_transition(game_start_layer.id(), 0)', intro_delay);
+        setTimeout(() => kiigame.do_transition(game_start_layer.id(), 0), intro_delay);
 	}
 	// If no number, grey out buttons that can't be used
 	if (input_text.getText().length == 0) {

--- a/latkazombit.js
+++ b/latkazombit.js
@@ -1,4 +1,5 @@
-import kiigame, {
+import {
+    KiiGame,
     stage,
     texts_json,
     game_start_layer,
@@ -6,6 +7,8 @@ import kiigame, {
     menu,
     character_animations
 } from './kiigame.js';
+
+let kiigame = new KiiGame();
 
 var legends_json = JSON.parse(kiigame.getJSON('legends.json'));
 

--- a/package.json
+++ b/package.json
@@ -20,10 +20,11 @@
   "devDependencies": {
     "@types/sinon-chai": "^3.2.3",
     "chai": "^4.2.0",
+    "esm": "^3.2.25",
     "mocha": "^6.2.0",
     "sinon": "^7.5.0"
   },
   "scripts": {
-    "test": "mocha test/**/*.js"
+    "test": "mocha -r esm test/**/*.js"
   }
 }

--- a/test/view/sequence/konvadata/testSequenceBuilder.js
+++ b/test/view/sequence/konvadata/testSequenceBuilder.js
@@ -1,8 +1,10 @@
-var chai = require('chai');
-var sinon = require('sinon');
+import chai from 'chai';
+import sinon from 'sinon';
+import SequenceBuilder from '../../../../view/sequence/konvadata/SequenceBuilder.js';
+import SlideBuilder from '../../../../view/sequence/konvadata/SlideBuilder.js';
+
 var assert = chai.assert;
-SequenceBuilder = require('../../../../view/sequence/konvadata/SequenceBuilder.js');
-SlideBuilder = require('../../../../view/sequence/konvadata/SlideBuilder.js');
+
 var slideBuilderStub = sinon.createStubInstance(SlideBuilder);
 slideBuilderStub.build.withArgs(
     {

--- a/test/view/sequence/konvadata/testSequencesBuilder.js
+++ b/test/view/sequence/konvadata/testSequencesBuilder.js
@@ -1,8 +1,10 @@
-var chai = require('chai');
-var sinon = require('sinon');
+import chai from 'chai';
+import sinon from 'sinon';
+import SequencesBuilder from '../../../../view/sequence/konvadata/SequencesBuilder.js';
+import SequenceBuilder from '../../../../view/sequence/konvadata/SequenceBuilder.js';
+
 var assert = chai.assert;
-SequencesBuilder = require('../../../../view/sequence/konvadata/SequencesBuilder.js');
-SequenceBuilder = require('../../../../view/sequence/konvadata/SequenceBuilder.js');
+
 var sequenceBuilderStub = sinon.createStubInstance(SequenceBuilder);
 sequenceBuilderStub.build.withArgs([], "intro").returns({ "data": "intro"});
 sequenceBuilderStub.build.withArgs([], "outro").returns({ "data": "outro"});

--- a/test/view/sequence/konvadata/testSlideBuilder.js
+++ b/test/view/sequence/konvadata/testSlideBuilder.js
@@ -1,8 +1,10 @@
-var chai = require('chai');
-var sinon = require('sinon');
+import chai from 'chai';
+import sinon from 'sinon';
+import SlideBuilder from '../../../../view/sequence/konvadata/SlideBuilder.js';
+import TextBuilder from '../../../../view/sequence/konvadata/TextBuilder.js';
+
 var assert = chai.assert;
-SlideBuilder = require('../../../../view/sequence/konvadata/SlideBuilder.js');
-TextBuilder = require('../../../../view/sequence/konvadata/TextBuilder.js');
+
 var textBuilderStub = sinon.createStubInstance(TextBuilder);
 textBuilderStub.build.returns(
     {

--- a/test/view/sequence/konvadata/testTextBuilder.js
+++ b/test/view/sequence/konvadata/testTextBuilder.js
@@ -1,6 +1,7 @@
-var chai = require('chai');
+import chai from 'chai';
+import TextBuilder from '../../../../view/sequence/konvadata/TextBuilder.js';
+
 var assert = chai.assert;
-TextBuilder = require('../../../../view/sequence/konvadata/TextBuilder.js');
 
 describe('Test sequence TextBuilder', function(){
     it('it should build expected JSON object with Text data', function(){

--- a/test/view/stage/konvadata/testLayerAdder.js
+++ b/test/view/stage/konvadata/testLayerAdder.js
@@ -1,6 +1,7 @@
-var chai = require('chai');
+import chai from 'chai';
+import LayerAdder from '../../../../view/stage/konvadata/LayerAdder.js';
+
 var assert = chai.assert;
-LayerAdder = require('../../../../view/stage/konvadata/LayerAdder.js');
 
 describe('Test stage LayerAdder', function(){
     it('should splice given object after specified layer', function(){

--- a/test/view/stage/konvadata/testLayerChildAdder.js
+++ b/test/view/stage/konvadata/testLayerChildAdder.js
@@ -1,6 +1,7 @@
-var chai = require('chai');
+import chai from 'chai';
+import LayerChildAdder from '../../../../view/stage/konvadata/LayerChildAdder.js';
+
 var assert = chai.assert;
-LayerChildAdder = require('../../../../view/stage/konvadata/LayerChildAdder.js');
 
 describe('Test stage LayerChildAdder', function(){
     it('should add children to the specified layer', function(){

--- a/util/JSONGetter.js
+++ b/util/JSONGetter.js
@@ -12,4 +12,4 @@ class JSONGetter {
     }
 }
 
-module.exports = JSONGetter;
+export default JSONGetter;

--- a/view/sequence/konvadata/SequenceBuilder.js
+++ b/view/sequence/konvadata/SequenceBuilder.js
@@ -21,4 +21,4 @@ class SequenceBuilder {
     }
 }
 
-module.exports = SequenceBuilder;
+export default SequenceBuilder;

--- a/view/sequence/konvadata/SequencesBuilder.js
+++ b/view/sequence/konvadata/SequencesBuilder.js
@@ -18,4 +18,4 @@ class SequencesBuilder {
     }
 }
 
-module.exports = SequencesBuilder;
+export default SequencesBuilder;

--- a/view/sequence/konvadata/SlideBuilder.js
+++ b/view/sequence/konvadata/SlideBuilder.js
@@ -45,4 +45,4 @@ class SlideBuilder {
     }
 }
 
-module.exports = SlideBuilder;
+export default SlideBuilder;

--- a/view/sequence/konvadata/TextBuilder.js
+++ b/view/sequence/konvadata/TextBuilder.js
@@ -22,4 +22,4 @@ class TextBuilder {
     }
 }
 
-module.exports = TextBuilder;
+export default TextBuilder;

--- a/view/stage/konvadata/LayerAdder.js
+++ b/view/stage/konvadata/LayerAdder.js
@@ -27,4 +27,4 @@ class LayerAdder {
     }
 }
 
-module.exports = LayerAdder;
+export default LayerAdder;

--- a/view/stage/konvadata/LayerChildAdder.js
+++ b/view/stage/konvadata/LayerChildAdder.js
@@ -24,4 +24,4 @@ class LayerChildAdder {
     }
 }
 
-module.exports = LayerChildAdder;
+export default LayerChildAdder;


### PR DESCRIPTION
This PR migrates the codebase to [ES6 modules](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Modules) (the official module standard), enabling more solid namespacing, loading, bundling and other cool stuff. This also makes it easier to convert the engine to a standalone library later on.

Some extra refactoring was done to make the engine play nice with the new structure (ES6 modules use [strict mode](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Strict_mode) by default). mainly changing the old-style anonymous functions to arrow functions to use the proper execution context for the `this` keyword without the messy `bind(this)` method calls.

Tested by checking that Lätkäzombit can be played through without errors and ensuring that all tests are passed.

The next step is to add a bundler, import dependencies (Konva) idiomatically and prepare the project to be published as an npm package. The engine could then be used as a dependency for e.g. [the editor](https://github.com/jnnl/kged). This also allows Lätkäzombit to be easily moved to its own project.