### PR TITLE
Add bundling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 node_modules/
+public/
+dist/
 yarn.lock

--- a/README.md
+++ b/README.md
@@ -15,9 +15,10 @@ The game is implemented as a web page. Therefore you need to run a web server on
  * Install and run Apache (for example see https://help.ubuntu.com/community/ApacheMySQLPHP)
  * Install npm (for example see https://www.sitepoint.com/beginners-guide-node-package-manager/)
  * Clone the repository (or just get the files)
- * Run npm install to get dependencies
+ * Run `npm install` to get dependencies
+ * Run `npm run dev` to build a development bundle. The bundle is built to the `public/` directory.
  * Put the files (including folders) to your webserver directory (for example /var/www/)
- * Open the kiigame.html in your browser (for example http://localhost/kiigame.html)
+ * Open the kiigame.html in your browser (for example http://localhost/public/kiigame.html)
 
 Running unit tests
 ------------------

--- a/kiigame.html
+++ b/kiigame.html
@@ -11,8 +11,6 @@
   </head>
   <body>
     <div id="container"></div>
-
-    <script src="node_modules/konva/konva.min.js"></script>
     <script type="module" src="latkazombit.js"></script>
   </body>
   

--- a/kiigame.js
+++ b/kiigame.js
@@ -1,3 +1,5 @@
+import Konva from 'konva';
+
 import JSONGetter from './util/JSONGetter.js';
 import LayerAdder from './view/stage/konvadata/LayerAdder.js';
 import LayerChildAdder from './view/stage/konvadata/LayerChildAdder.js';
@@ -1348,5 +1350,3 @@ export class KiiGame {
     }
     
 }
-
-export default KiiGame;

--- a/package.json
+++ b/package.json
@@ -3,7 +3,9 @@
   "private": true,
   "version": "0.3.0",
   "description": "Lightweight point & click adventure game engine",
-  "main": "kiigame.js",
+  "main": "dist/kiigame.cjs.js",
+  "module": "dist/kiigame.esm.js",
+  "browser": "dist/kiigame.umd.js",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/evktalo/kiigame.git"
@@ -22,9 +24,18 @@
     "chai": "^4.2.0",
     "esm": "^3.2.25",
     "mocha": "^6.2.0",
+    "rollup": "^1.27.0",
+    "rollup-plugin-commonjs": "^10.1.0",
+    "rollup-plugin-copy": "^3.1.0",
+    "rollup-plugin-node-resolve": "^5.2.0",
     "sinon": "^7.5.0"
   },
   "scripts": {
+    "build": "rollup -c --config --configBuild",
+    "dev": "rollup -c --config --configDev",
     "test": "mocha -r esm test/**/*.js"
-  }
+  },
+  "files": [
+    "dist"
+  ]
 }

--- a/package.json
+++ b/package.json
@@ -31,8 +31,8 @@
     "sinon": "^7.5.0"
   },
   "scripts": {
-    "build": "rollup -c --config --configBuild",
-    "dev": "rollup -c --config --configDev",
+    "build": "./node_modules/.bin/rollup -c --config --configBuild",
+    "dev": "./node_modules/.bin/rollup -c --config --configDev",
     "test": "mocha -r esm test/**/*.js"
   },
   "files": [

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,0 +1,60 @@
+import resolve from 'rollup-plugin-node-resolve';
+import commonjs from 'rollup-plugin-commonjs';
+import copy from 'rollup-plugin-copy';
+import pkg from './package.json';
+
+export const build = [
+    {
+        input: 'kiigame.js',
+        output: {
+            name: 'kiigame',
+            file: pkg.browser,
+            format: 'umd'
+        },
+        plugins: [
+            resolve(),
+            commonjs()
+        ]
+    },
+
+    {
+        input: 'kiigame.js',
+        external: ['konva'],
+        output: [
+            { file: pkg.main, format: 'cjs' },
+            { file: pkg.module, format: 'es' }
+        ]
+    }
+];
+
+export const dev = {
+    input: 'latkazombit.js',
+    output: {
+        name: 'kiigame',
+        file: 'public/latkazombit.js',
+        format: 'iife',
+        sourcemap: true
+    },
+    plugins: [
+        resolve(),
+        commonjs(),
+        copy({
+            targets: [
+                { src: 'kiigame.html', dest: 'public/' },
+                { src: '*.json', dest: 'public/' },
+                { src: 'audio/**/*', dest: 'public/audio/' },
+                { src: 'images/**/*', dest: 'public/images/' },
+                { src: 'util/**/*', dest: 'public/util/' },
+                { src: 'view/**/*', dest: 'public/view/' }
+            ]
+        })
+    ]
+}
+
+export default cli => {
+  if (cli.configBuild === true) {
+    return build;
+  }
+  return dev;
+}
+


### PR DESCRIPTION
This PR adds module bundling using [Rollup](https://rollupjs.org). It enables the engine to be used as a dependency in other projects and removes rest of the old-style script tag imports. Additional features can be easily added using [Rollup plugins](https://github.com/rollup/awesome) if needed. For example, the bundle size can be reduced using a minifier such as [Terser](https://github.com/TrySound/rollup-plugin-terser).

Executing `npm run build` builds the library bundle to `dist/` while `npm run dev` builds the development bundle to `public/`. Running Lätkäzombit from the project now requires executing the latter and accessing the files in `public/` instead of the root directory.

These changes now make it possible to publish the project as a dependency as well! 